### PR TITLE
Fix/generate kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ edit the `default` namespace:
 ```bash
 kubectl create serviceaccount github-actions --namespace default
 kubectl create rolebinding github-actions --clusterrole edit --serviceaccount default:github-actions
+kubectl apply -f scripts/secret.yaml
 ```
 
 Next, you need to fetch the service account's authentication token and build a

--- a/scripts/generate-kubeconfig.sh
+++ b/scripts/generate-kubeconfig.sh
@@ -5,24 +5,25 @@ set -e
 
 ### These are the parameters you can set when calling this script:
 NAMESPACE="${NAMESPACE:-default}"
+RESOURCE_NAME="github-actions"
 ###
 
 
 echo "⏳ Fetching service account credentials..."
-SA_SECRET_NAME=$(kubectl get serviceaccount github-actions --namespace "${NAMESPACE}" --output go-template='{{ (index .secrets 0).name }}')
+SA_SECRET_NAME=$(kubectl get secrets "${RESOURCE_NAME}" -o json | jq -r .data.token | base64 -d)
 echo "✅ Service account credentials fetched."
 echo
 
 echo "⏳ Adding Kubernetes API server to kubectl configuration..."
 KUBECONFIG_SERVER=$(kubectl config view --minify --output go-template='{{ (index .clusters 0).cluster.server }}')
-kubectl get secret $SA_SECRET_NAME --namespace "${NAMESPACE}" --output go-template='{{ index .data "ca.crt" }}' | base64 --decode > /tmp/kubeconfig-ca.crt
+kubectl get secret "${RESOURCE_NAME}" --namespace "${NAMESPACE}" --output go-template='{{ index .data "ca.crt" }}' | base64 --decode > /tmp/kubeconfig-ca.crt
 kubectl --kubeconfig /tmp/kubeconfig.yml config set-cluster production --server=$KUBECONFIG_SERVER --certificate-authority /tmp/kubeconfig-ca.crt --embed-certs=true
 rm /tmp/kubeconfig-ca.crt
 echo "✅ Kubernetes API server added."
 echo
 
 echo "⏳ Adding authentication token to kubectl configuration..."
-KUBECONFIG_TOKEN=$(kubectl get secret $SA_SECRET_NAME --namespace "${NAMESPACE}" --output go-template='{{ .data.token }}' | base64 --decode)
+KUBECONFIG_TOKEN=$(kubectl get secret "${RESOURCE_NAME}" --namespace "${NAMESPACE}" --output go-template='{{ .data.token }}' | base64 --decode)
 kubectl --kubeconfig /tmp/kubeconfig.yml config set-credentials github-actions --token $KUBECONFIG_TOKEN
 kubectl --kubeconfig /tmp/kubeconfig.yml config set-context github-actions-production --cluster production --user github-actions --namespace "${NAMESPACE}"
 kubectl --kubeconfig /tmp/kubeconfig.yml config use-context github-actions-production
@@ -30,8 +31,8 @@ echo "✅ Authentication token added."
 echo
 
 echo "⏳ Converting configuration to base64..."
-KUBECONFIG_B64="$(base64 --input /tmp/kubeconfig.yml)"
-rm /tmp/kubeconfig.yml
+KUBECONFIG_B64="$(base64 /tmp/kubeconfig.yml)"
+#rm /tmp/kubeconfig.yml
 echo "✅ Configuration converted."
 echo
 

--- a/scripts/generate-kubeconfig.sh
+++ b/scripts/generate-kubeconfig.sh
@@ -32,7 +32,7 @@ echo
 
 echo "⏳ Converting configuration to base64..."
 KUBECONFIG_B64="$(base64 /tmp/kubeconfig.yml)"
-#rm /tmp/kubeconfig.yml
+rm /tmp/kubeconfig.yml
 echo "✅ Configuration converted."
 echo
 

--- a/scripts/secret.yaml
+++ b/scripts/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: github-actions
+  annotations:
+    kubernetes.io/service-account.name: "github-actions"


### PR DESCRIPTION
Fixing the broken generate-kubeconfig script
Since kube 1.24, the creation of service account does not automatically create secret
this MR adds the manifest for the creation of a sa token and change the script to retrive the kube config accordingly